### PR TITLE
fix: 미니홈피 개별 방문자 카운터 기능 구현

### DIFF
--- a/minihome/hwangyooseok/js/script.js
+++ b/minihome/hwangyooseok/js/script.js
@@ -39,8 +39,28 @@ function updateVisitorCount() {
     // 오늘 날짜 가져오기
     const today = new Date().toDateString();
     
+    // 현재 페이지 경로에서 팀원 이름 추출
+    const pathSegments = window.location.pathname.split('/');
+    let memberName = '';
+    
+    // 경로에서 minihome 폴더 다음에 오는 세그먼트가 팀원 이름
+    for (let i = 0; i < pathSegments.length; i++) {
+        if (pathSegments[i] === 'minihome' && i + 1 < pathSegments.length) {
+            memberName = pathSegments[i + 1];
+            break;
+        }
+    }
+    
+    // 팀원 이름이 추출되지 않은 경우 기본값 설정
+    if (!memberName) {
+        memberName = 'hwangyooseok';
+    }
+    
+    // localStorage 키 생성 (팀원별로 고유한 키 사용)
+    const visitorKey = 'cyworld_visitor_' + memberName;
+    
     // localStorage에서 방문 기록 가져오기
-    let visitorData = localStorage.getItem('cyworld_visitor');
+    let visitorData = localStorage.getItem(visitorKey);
     
     if (visitorData) {
         visitorData = JSON.parse(visitorData);
@@ -71,7 +91,7 @@ function updateVisitorCount() {
     }
     
     // localStorage에 방문 데이터 저장
-    localStorage.setItem('cyworld_visitor', JSON.stringify(visitorData));
+    localStorage.setItem(visitorKey, JSON.stringify(visitorData));
     
     // 화면에 방문자 수 표시
     document.querySelector('.today-count').textContent = visitorData.today;

--- a/minihome/kimsiyeon/js/script.js
+++ b/minihome/kimsiyeon/js/script.js
@@ -39,8 +39,28 @@ function updateVisitorCount() {
     // 오늘 날짜 가져오기
     const today = new Date().toDateString();
     
+    // 현재 페이지 경로에서 팀원 이름 추출
+    const pathSegments = window.location.pathname.split('/');
+    let memberName = '';
+    
+    // 경로에서 minihome 폴더 다음에 오는 세그먼트가 팀원 이름
+    for (let i = 0; i < pathSegments.length; i++) {
+        if (pathSegments[i] === 'minihome' && i + 1 < pathSegments.length) {
+            memberName = pathSegments[i + 1];
+            break;
+        }
+    }
+    
+    // 팀원 이름이 추출되지 않은 경우 기본값 설정
+    if (!memberName) {
+        memberName = 'kimsiyeon';
+    }
+    
+    // localStorage 키 생성 (팀원별로 고유한 키 사용)
+    const visitorKey = 'cyworld_visitor_' + memberName;
+    
     // localStorage에서 방문 기록 가져오기
-    let visitorData = localStorage.getItem('cyworld_visitor');
+    let visitorData = localStorage.getItem(visitorKey);
     
     if (visitorData) {
         visitorData = JSON.parse(visitorData);
@@ -71,7 +91,7 @@ function updateVisitorCount() {
     }
     
     // localStorage에 방문 데이터 저장
-    localStorage.setItem('cyworld_visitor', JSON.stringify(visitorData));
+    localStorage.setItem(visitorKey, JSON.stringify(visitorData));
     
     // 화면에 방문자 수 표시
     document.querySelector('.today-count').textContent = visitorData.today;

--- a/minihome/leejaesung/js/script.js
+++ b/minihome/leejaesung/js/script.js
@@ -39,8 +39,28 @@ function updateVisitorCount() {
     // 오늘 날짜 가져오기
     const today = new Date().toDateString();
     
+    // 현재 페이지 경로에서 팀원 이름 추출
+    const pathSegments = window.location.pathname.split('/');
+    let memberName = '';
+    
+    // 경로에서 minihome 폴더 다음에 오는 세그먼트가 팀원 이름
+    for (let i = 0; i < pathSegments.length; i++) {
+        if (pathSegments[i] === 'minihome' && i + 1 < pathSegments.length) {
+            memberName = pathSegments[i + 1];
+            break;
+        }
+    }
+    
+    // 팀원 이름이 추출되지 않은 경우 기본값 설정
+    if (!memberName) {
+        memberName = 'leejaesung';
+    }
+    
+    // localStorage 키 생성 (팀원별로 고유한 키 사용)
+    const visitorKey = 'cyworld_visitor_' + memberName;
+    
     // localStorage에서 방문 기록 가져오기
-    let visitorData = localStorage.getItem('cyworld_visitor');
+    let visitorData = localStorage.getItem(visitorKey);
     
     if (visitorData) {
         visitorData = JSON.parse(visitorData);
@@ -71,7 +91,7 @@ function updateVisitorCount() {
     }
     
     // localStorage에 방문 데이터 저장
-    localStorage.setItem('cyworld_visitor', JSON.stringify(visitorData));
+    localStorage.setItem(visitorKey, JSON.stringify(visitorData));
     
     // 화면에 방문자 수 표시
     document.querySelector('.today-count').textContent = visitorData.today;

--- a/minihome/leejaewon/js/script.js
+++ b/minihome/leejaewon/js/script.js
@@ -39,8 +39,28 @@ function updateVisitorCount() {
     // 오늘 날짜 가져오기
     const today = new Date().toDateString();
     
+    // 현재 페이지 경로에서 팀원 이름 추출
+    const pathSegments = window.location.pathname.split('/');
+    let memberName = '';
+    
+    // 경로에서 minihome 폴더 다음에 오는 세그먼트가 팀원 이름
+    for (let i = 0; i < pathSegments.length; i++) {
+        if (pathSegments[i] === 'minihome' && i + 1 < pathSegments.length) {
+            memberName = pathSegments[i + 1];
+            break;
+        }
+    }
+    
+    // 팀원 이름이 추출되지 않은 경우 기본값 설정
+    if (!memberName) {
+        memberName = 'leejaewon';
+    }
+    
+    // localStorage 키 생성 (팀원별로 고유한 키 사용)
+    const visitorKey = 'cyworld_visitor_' + memberName;
+    
     // localStorage에서 방문 기록 가져오기
-    let visitorData = localStorage.getItem('cyworld_visitor');
+    let visitorData = localStorage.getItem(visitorKey);
     
     if (visitorData) {
         visitorData = JSON.parse(visitorData);
@@ -71,7 +91,7 @@ function updateVisitorCount() {
     }
     
     // localStorage에 방문 데이터 저장
-    localStorage.setItem('cyworld_visitor', JSON.stringify(visitorData));
+    localStorage.setItem(visitorKey, JSON.stringify(visitorData));
     
     // 화면에 방문자 수 표시
     document.querySelector('.today-count').textContent = visitorData.today;


### PR DESCRIPTION
각 팀원의 미니홈피 페이지가 독립적인 방문자 수를 가질 수 있도록 수정함
- localStorage 키를 'cyworld_visitor'에서 'cyworld_visitor_팀원이름' 형식으로 변경
- URL 경로에서 팀원 이름 동적 추출 기능 추가
- 모든 팀원 페이지에 동일하게 적용

Resolves: 방문자 카운터 공유 문제